### PR TITLE
Fixing netlify page not found error

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,11 @@
+[build]
+  command = "npm run build"
+  publish = "static/"
+
+# Redirect rule defined in "_redirect" isn't working.
+# using netlify.toml instead.
+# Refer to the documentation - https://www.netlify.com/docs/netlify-toml-reference/#getting-started
+[[redirects]]
+  from = "/*"
+  to = "/index.mdx"
+  status = 200


### PR DESCRIPTION
Page not found error due to index.mdx instead of index.html. Added netlify.toml to fix issue